### PR TITLE
Update US06_USA_Plex.m3u

### DIFF
--- a/US06_USA_Plex.m3u
+++ b/US06_USA_Plex.m3u
@@ -1,137 +1,137 @@
 #EXTM3U
-#EXTINF:-1 tvg-name="************** PLEX USA *********",************** USA PLEX *********
+#EXTINF:-1 tvg-ID="" tvg-name="************** PLEX USA *********",************** USA PLEX *********
 https://66fbef2650a94f95ad9eb85816482b11.mediatailor.us-west-2.amazonaws.com/v1/manifest/ba62fe743df0fe93366eba3a257d792884136c7f/LINEAR-12-AFV-PLEX/b2bc9f3a-4e07-4879-8cbd-069986706a88/0.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/FLKdEzZ.png" group-title="PLEX USA",AFV Family
+#EXTINF:-1 tvg-ID="PLEX.TV.031.AFV.Family" tvg-name="AFV Family" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/afv-family.png" group-title="PLEX USA",AFV Family
 https://66fbef2650a94f95ad9eb85816482b11.mediatailor.us-west-2.amazonaws.com/v1/manifest/ba62fe743df0fe93366eba3a257d792884136c7f/LINEAR-12-AFV-PLEX/b2bc9f3a-4e07-4879-8cbd-069986706a88/0.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/17WHXnc.png" group-title="PLEX USA",Camp Spoopy
+#EXTINF:-1 tvg-ID="" tvg-name="Camp Spoopy" tvg-logo="https://i.imgur.com/17WHXnc.png" group-title="PLEX USA",Camp Spoopy
 https://stream.ads.ottera.tv/playlist.m3u8?network_id=269&livestream=1&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5f77a99416621400402b3dc1&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=1&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/gXFv0rV.jpg" group-title="PLEX USA",Channel Fight
+#EXTINF:-1 tvg-ID="PLEX.TV.092.Channel.Fight" tvg-name="Channel Fight" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/channel-fight.png" group-title="PLEX USA",Channel Fight
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=68&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5f0ff265d71dcb00449ec02a&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=0&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/tvTPKc0.jpg" group-title="PLEX USA",Chopper Town
+#EXTINF:-1 tvg-ID="PLEX.TV.046.Choppertown" tvg-name="Choppertown" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/choppertown.png" group-title="PLEX USA",Choppertown
 https://6c4d10b7b847421db903914a39b00eb7.mediatailor.us-west-2.amazonaws.com/v1/manifest/ba62fe743df0fe93366eba3a257d792884136c7f/LINEAR-11-CHOPPERTOWN-PLEX/67d41d7e-f2c4-4005-abab-22174f1f8b43/0.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/RKzHHRC.jpg" group-title="PLEX USA",Cooking Panda
+#EXTINF:-1 tvg-ID="PLEX.TV.041.Cooking.Panda" tvg-name="Cooking Panda" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/cooking-panda.png" group-title="PLEX USA",Cooking Panda
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=46&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5f07e9fdf313eb0041bbecda&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=0&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/4Ugp1ju.jpg" group-title="PLEX USA",Design
+#EXTINF:-1 tvg-ID="PLEX.TV.042.The.Design.Network" tvg-name="The Design Network" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/thedesignnetwork_tdn_5.png" group-title="PLEX USA",The Design Network
 https://d06b09a740824c49b9937130662ef38a.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_TheDesignNetwork/7c1469be-63d2-44de-8083-ee421aeb53df/4.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/TuCztKV.png" group-title="PLEX USA",Drink TV
+#EXTINF:-1 tvg-ID="PLEX.TV.040.DrinkTV" tvg-name="DrinkTV" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/drink-tv.png" group-title="PLEX USA",DrinkTV
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=62&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5eea605474085f0040ddc76a&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=0&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/YAQi1PP.png" group-title="PLEX USA",Fail Army
+#EXTINF:-1 tvg-ID="PLEX.TV.036.FailArmy" tvg-name="FailArmy" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/failarmy_linear_.png" group-title="PLEX USA",FailArmy
 https://9c17e762ec814557b3516dd3e0a7ca56.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex-intl_FailArmy/ade59f27-be9b-4b71-b8dc-05928c1dfdf4/2.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/4dMoXtm.jpg" group-title="PLEX USA",Film Stream
+#EXTINF:-1 tvg-ID="PLEX.TV.070.Filmstream" tvg-name="Filmstream" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/spi_filmstream_1.png" group-title="PLEX USA",Filmstream
 https://b58cbafb283b4d0b9610407d0e766d64.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_Filmstream/29d2a5e9-0e59-4a8b-b906-0f82d8fa81b8/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/F65M8sk.png" group-title="PLEX USA",Game Show
+#EXTINF:-1 tvg-ID="PLEX.TV.051.Game.Show.Central" tvg-name="Game Show Central" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/gsn_gameshowchannnel_1.png" group-title="PLEX USA",Game Show Central
 https://ffcf6c437bec4f3988224ccfe150499d.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_GameShowCentral/c3d6136c-3a3e-4690-949d-8dcebfe43fc2/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/O1rYDXF.png" group-title="PLEX USA",Glewed TV
+#EXTINF:-1 tvg-ID="PLEX.TV.061.Glewed.TV" tvg-name="Glewed.TV" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/glewedtv_3.png" group-title="PLEX USA",Glewed.TV
 https://e54c4fcc08f14de7bc1094ca25cb9d29.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_GlewedTV/d1a011d0-5758-439c-9939-ef96c8e13323/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/mQ7CMiF.png" group-title="PLEX USA",Gravitas Movies
+#EXTINF:-1 tvg-ID="PLEX.TV.075.Gravitas.Movies" tvg-name="Gravitas Movies" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/gravitas_movies.png" group-title="PLEX USA",Gravitas Movies
 https://cba5182b39c145c2b96ecc5c3f72e41a.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_GravitasMovies/b465c16f-0c23-4bf0-9a52-e1d87cb0f5ee/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/BfPMUrU.jpg" group-title="PLEX USA",Gusto TV
+#EXTINF:-1 tvg-ID="PLEX.TV.038.Gusto.TV" tvg-name="Gusto TV" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/gusto-tv-logo.png" group-title="PLEX USA",Gusto TV
 https://gustous-plex.amagi.tv/hls/amagi_hls_data_gustoAAAA-gustous-plex/CDN/playlist.m3u8?us_privacy=1---&did=df8e1a36-847d-5096-86a7-3803ed330ede&dnt=0&X-Plex-Token=MorUy57ijWhGe4ixZb_T&channelId=5f8746eabd529300418246d9
-#EXTINF:-1 tvg-logo="https://i.imgur.com/Afka45R.jpg" group-title="PLEX USA",Hollywood Classics
+#EXTINF:-1 tvg-ID="PLEX.TV.071.Hollywood.Classics" tvg-name="Hollywood Classics" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/vitor_hollywoodclassics_1.png" group-title="PLEX USA",Hollywood Classics
 https://fef5003bb7e7447ab21a2c3fd81e3b74.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_HollywoodClassics/5e48be49-66f7-4712-9fff-347b1ae7afbd/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/XcxeVNe.jpg" group-title="PLEX USA",Holly Wires
+#EXTINF:-1 tvg-ID="PLEX.TV.027.Hollywire" tvg-name="Hollywire" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/hollywire_samsung.png" group-title="PLEX USA",Hollywire
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=141&live=1&avod=1&ip=91.97.129.97&ua=Mozilla%2F5.0%20(Windows%20NT%206.1%3B%20rv%3A83.0)%20Gecko%2F20100101%20Firefox%2F83.0&player_height=691&player_width=1224&is_lat=0&content_channel=5f5132e662fe160040f26c50&app_bundle=ctv.hollywire&app_name=plex&did=df8e1a36-847d-5096-86a7-3803ed330ede&content_dist_id=MorUy57ijWhGe4ixZb_T&app_domain=app.plex.tv&app_store_url=https%3A%2F%2Fapp.plex.tv&us-privacy=1---&gdpr=1&consent=0&coppa=0&device_type=desktop
-#EXTINF:-1 tvg-logo="https://i.imgur.com/UR5w7g9.png" group-title="PLEX USA",IGN TV
+#EXTINF:-1 tvg-ID="PLEX.TV.096.IGN.TV" tvg-name="IGN TV" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/ign-tv.png" group-title="PLEX USA",IGN TV
 https://ign-plex.amagi.tv/amRdirect/us_privacy=1---&did=61e24c69-c657-5bf3-b863-7cdc122e912c&dnt=0&X-Plex-Token=yd2t7_mqLeso7PyTUYZ6&channelId=5eea605474085f0040ddc77c/hls/amagi_hls_data_ignAAAAAA-ign-plexA/CDN/playlist.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/VZOAHVr.png" group-title="PLEX USA",KiDoodle TV
+#EXTINF:-1 tvg-ID="PLEX.TV.013.Kidoodle.TV" tvg-name="Kidoodle TV" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/kidoodletv_logo_v3.png" group-title="PLEX USA",Kidoodle TV
 https://7c16fcbdbd1b4a74b712c2052303b6bb.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_KidoodleTV/1d045896-8061-414f-b467-2b5afadb837e/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/JsHqCfm.jpg" group-title="PLEX USA",Latido Music
+#EXTINF:-1 tvg-ID="PLEX.TV.111.Latido.Music" tvg-name="Latido Music" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/latido-music-logo.png" group-title="PLEX USA",Latido Music
 https://vidaprimo-plex.amagi.tv/amRdirect/us_privacy=1---&did=3f68a808-1437-5e57-9eaf-7a12279d9462&dnt=0&X-Plex-Token=nkPyxTGm41qFS7TFC9Yh&channelId=5f598c33465f860041cd2dee/hls/amagi_hls_data_vidaprimo-vidaprimo-plex/CDN/720x404_1460800/index.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/7wXWzqY.jpg" group-title="PLEX USA",Law and Crime
+#EXTINF:-1 tvg-ID="PLEX.TV.050.Law.&.Crime" tvg-name="Law & Crime" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/lawandcrime_samsung.png" group-title="PLEX USA",Law & Crime
 https://0e6490ecfe9b4c7696b00aa6767caa75.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_LawAndCrime/3764ff82-e9c3-4cd8-a6d7-fd42b777ed75/1.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/jTfpBCT.jpg" group-title="PLEX USA",M Now
+#EXTINF:-1 tvg-ID="PLEX.TV.081.MagellanTV.NOW" tvg-name="MagellanTV NOW" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/magellantv_1.png" group-title="PLEX USA",MagellanTV NOW
 https://96f6ab4a7f3c434699b8502a36d670fc.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_MagellanTV/94d277d1-8703-4f03-a2d8-69e91ff314fb/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/pV4i9fX.jpg" group-title="PLEX USA",Maverick Black Cinema
+#EXTINF:-1 tvg-ID="PLEX.TV.072.Maverick.Black.Cinema" tvg-name="Maverick Black Cinema" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/maverick_maverick_black_cinema_2.png" group-title="PLEX USA",Maverick Black Cinema
 https://bad6f547d5364da0b2fe3080c5a48068.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_MaverickBlackCinema/fd0e4439-3d12-4d07-99b6-7f79ceeb94c2/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/IZCWyc7.png" group-title="PLEX USA",MAV TV Motorsports Network
+#EXTINF:-1 tvg-ID="PLEX.TV.085.MAV.TV.Select" tvg-name="MAV TV Select" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/mavtv_1.png" group-title="PLEX USA",MAV TV Select
 https://f29b0125f5c34020abde7393eb2b43e4.mediatailor.us-east-1.amazonaws.com/v1/master/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_MAVTVMotorSportsNetwork/playlist.m3u8?ads.wurl_channel=611&ads.wurl_name=MAVTVMotorSportsNetwork&ads.us_privacy=1---&ads.psid=df8e1a36-847d-5096-86a7-3803ed330ede&ads.targetopt=0&ads.plex_token=MorUy57ijWhGe4ixZb_T&ads.plex_id=5f90ebc726350a002d40b136&ads.ua=Mozilla%2F5.0%20(Windows%20NT%206.1%3B%20rv%3A83.0)%20Gecko%2F20100101%20Firefox%2F83.0&ads.app_bundle=com.plexapp.desktop&ads.app_store_url=https%3A%2F%2Fapp.plex.tv&ads.gdpr=1&ads.consent=0
-#EXTINF:-1 tvg-logo="https://i.imgur.com/pU4n2Mc.jpg" group-title="PLEX USA",MIH TV
+#EXTINF:-1 tvg-ID="PLEX.TV.049.Made.In.Hollywood" tvg-name="Made In Hollywood" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/connection3_ent.png" group-title="PLEX USA",Made In Hollywood
 https://810196ba95e649839da0b32235393623.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_MadeInHollywood/72b302d2-2303-4e58-bf44-c9e7ae33495e/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/IDntpXG.jpg" group-title="PLEX USA",Monster Kids
+#EXTINF:-1 tvg-ID="PLEX.TV.018.Monster.Kids" tvg-name="Monster Kids" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/vitor_monsterkids_1-v2.png" group-title="PLEX USA",Monster Kids
 https://d8f9c7ca60f84037aad1ff1030ecfa2f.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_MonsterKids/c3ab9586-35f3-4813-8021-e9262efd4616/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/kBLm68h.png" group-title="PLEX USA",Nosey
+#EXTINF:-1 tvg-ID="PLEX.TV.006.Nosey" tvg-name="Nosey" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/nosey_2.png" group-title="PLEX USA",Nosey
 https://9c27771bc8af464c8588ae326fe26edd.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_Nosey/3e715e05-ef51-4db7-8499-59628359c65b/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/agEJ1IY.jpg" group-title="PLEX USA",Party Tyme Karaoke
+#EXTINF:-1 tvg-ID="PLEX.TV.117.Party.Tyme.Karaoke" tvg-name="Party Tyme Karaoke" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/party-tyme-karaoke.png" group-title="PLEX USA",Party Tyme Karaoke
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=64&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5f17a1a283581000409bd875&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=0&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/H2EAcw8.png" group-title="PLEX USA",People are awesome
+#EXTINF:-1 tvg-ID="PLEX.TV.063.People.are.Awesome" tvg-name="People are Awesome" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/jukin_peopleareawesome_1.png" group-title="PLEX USA",People are Awesome
 https://a357e37df8ec46719fdeffa29a3e8e40.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex-intl_PeopleAreAwesome/8fe64d6c-210c-42ac-8b42-8006b8721cf4/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/7PlpH3f.jpg" group-title="PLEX USA",Play Works
+#EXTINF:-1 tvg-ID="PLEX.TV.062.PlayWorks" tvg-name="PlayWorks" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/playworksdigital_playworks_1.png" group-title="PLEX USA",PlayWorks
 https://b12eca572da7423284734ca3a6242ea2.mediatailor.us-east-1.amazonaws.com/v1/master/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_PlayWorks/playlist.m3u8?ads.wurl_channel=512&ads.wurl_name=PlayWorks&ads.us_privacy=1---&ads.psid=df8e1a36-847d-5096-86a7-3803ed330ede&ads.targetopt=0&ads.plex_token=MorUy57ijWhGe4ixZb_T&ads.plex_id=5f0ff263d71dcb00449ec01e&ads.ua=Mozilla%2F5.0%20(Windows%20NT%206.1%3B%20rv%3A83.0)%20Gecko%2F20100101%20Firefox%2F83.0&ads.app_bundle=com.plexapp.desktop&ads.app_store_url=https%3A%2F%2Fapp.plex.tv&ads.gdpr=1&ads.consent=0
-#EXTINF:-1 tvg-logo="https://i.imgur.com/qld89Gc.jpg" group-title="PLEX USA",Players TV
+#EXTINF:-1 tvg-ID="PLEX.TV.095.PlayersTV" tvg-name="PlayersTV" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/playerstv-logo.png" group-title="PLEX USA",PlayersTV
 https://playerstv-plex.amagi.tv/hls/amagi_hls_data_plexAAAAA-playerstv-plex/CDN/playlist.m3u8?us_privacy=1---&did=df8e1a36-847d-5096-86a7-3803ed330ede&dnt=0&X-Plex-Token=MorUy57ijWhGe4ixZb_T&channelId=5f74cf81ffbe690040689f44
-#EXTINF:-1 tvg-logo="https://i.imgur.com/kFO675K.png" group-title="PLEX USA",Popstar! TV
+#EXTINF:-1 tvg-ID="PLEX.TV.052.PopStar!.TV" tvg-name="PopStar! TV" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/popstar-tv.png" group-title="PLEX USA",PopStar! TV
 https://linear-10.frequency.stream/dist/plex/10/hls/master/playlist.m3u8?ads.plex_token=MorUy57ijWhGe4ixZb_T&ads.plex_id=5ef11487d33ab9004048a1d6&ads.device_id=df8e1a36-847d-5096-86a7-3803ed330ede&ads.dnt=0&ads.us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/zK98jJZ.jpg" group-title="PLEX USA",Reuters
+#EXTINF:-1 tvg-ID="PLEX.TV.024.Reuters.Now" tvg-name="Reuters Now" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/reuters_reutersnow_1.png" group-title="PLEX USA",Reuters Now
 https://32ce4aad1eed49b1ba2999fb68d119c8.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_ReutersNow/678e78de-ad71-4747-936a-55da37f68898/6.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/5iyimXw.jpg" group-title="PLEX USA",Revry
+#EXTINF:-1 tvg-ID="PLEX.TV.054.Revry" tvg-name="Revry" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/revry-logo-v2.png" group-title="PLEX USA",Revry
 https://80b6878a343a4c37ae7c81c26e367b59.mediatailor.us-west-2.amazonaws.com/v1/manifest/ba62fe743df0fe93366eba3a257d792884136c7f/LINEAR-5-REVRY-PLEX/aa5b463a-e354-4b03-ab59-020c6cd3713e/0.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/4WhBqod.jpg" group-title="PLEX USA",Revry 2
+#EXTINF:-1 tvg-ID="PLEX.TV.055.Revry2" tvg-name="Revry2" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/revry2-logo-v2.png" group-title="PLEX USA",Revry2
 https://0bef58ceebc44ecbba8ed46a4b17de0c.mediatailor.us-west-2.amazonaws.com/v1/manifest/ba62fe743df0fe93366eba3a257d792884136c7f/LINEAR-43-REVRY2-PLEX/09eef831-6e1a-4f60-a138-77c0a1da8e06/0.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/kmidFU6.jpg" group-title="PLEX USA",Revry News
+#EXTINF:-1 tvg-ID="PLEX.TV.056.RevryNews" tvg-name="RevryNews" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/revrynews-logo-v2.png" group-title="PLEX USA",RevryNews
 https://0b4227d4da7e4ba4aa9d980f532fdc86.mediatailor.us-west-2.amazonaws.com/v1/manifest/ba62fe743df0fe93366eba3a257d792884136c7f/LINEAR-44-REVRYNOW-PLEX/384b6047-c4ba-41fa-93da-86bb345ec805/0.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/xFkw4wr.jpg" group-title="PLEX USA",So...Real
+#EXTINF:-1 tvg-ID="PLEX.TV.053.So...Real" tvg-name="So...Real" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/cinedigm_so_real_1.png" group-title="PLEX USA",So...Real
 https://e982c1e590144972a3c79888837ecd36.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_SoReal/78ee14fe-d1d9-4189-8b1f-e2b57a314963/0.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/QxhkEly.jpg" group-title="PLEX USA",Sports Grid
+#EXTINF:-1 tvg-ID="PLEX.TV.089.SportsGrid" tvg-name="SportsGrid" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/sportsgrid.png" group-title="PLEX USA",SportsGrid
 https://sportsgrid-plex.amagi.tv/amRdirect/us_privacy=1---&did=3f68a808-1437-5e57-9eaf-7a12279d9462&dnt=0&X-Plex-Token=nkPyxTGm41qFS7TFC9Yh&channelId=5ef11485d33ab9004048a1ca/hls/amagi_hls_data_plexAAAAA-sportsgrid-plex/CDN/1280x720_2855600/index.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/jTrTJZr.jpg" group-title="PLEX USA",Sqadl
+#EXTINF:-1 tvg-ID="PLEX.TV.100.SKWAD" tvg-name="SKWAD" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/skwad-logo.png" group-title="PLEX USA",SKWAD
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=39&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5f12332eeca6a20040b328e5&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=1&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/TkFfIt8.jpg" group-title="PLEX USA",Surf Now TV
+#EXTINF:-1 tvg-ID="PLEX.TV.087.Surf.Now.TV" tvg-name="Surf Now TV" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/1091_surfnowtv_1.png" group-title="PLEX USA",Surf Now TV
 https://0e52d42a12b74a218576cd628069fa50.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_SurfNowTV/1e05afbf-0234-4d61-9406-20bf6719fce5/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/XrBn1ZO.jpg" group-title="PLEX USA",Tankee
+#EXTINF:-1 tvg-ID="PLEX.TV.098.Tankee" tvg-name="Tankee" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/playworksdigital_tankee_1-v2.png" group-title="PLEX USA",Tankee
 https://72c5b87587c545558c3170ab55de2915.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_Tankee/282d947f-8e33-4bcb-8d98-3c7d9254f6f5/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/FjJEYsf.jpg" group-title="PLEX USA",TG Toon Googles
+#EXTINF:-1 tvg-ID="" tvg-name="TG Toon Googles" tvg-logo="https://i.imgur.com/FjJEYsf.jpg" group-title="PLEX USA",TG Toon Googles
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=37&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5eea605574085f0040ddc794&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=1&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/Y5R0pvG.jpg" group-title="PLEX USA",The Boat Show
+#EXTINF:-1 tvg-ID="PLEX.TV.045.The.Boat.Show" tvg-name="The Boat Show" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/vitor_theboatshow_1.png" group-title="PLEX USA",The Boat Show
 https://e99f8e610cd24f40a2c5f054d33aad3a.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex_TheBoatShow/820e6d4e-cebb-4533-adf7-d0193f320ac9/4.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/piZoGcS.jpg" group-title="PLEX USA",The Film Detective
+#EXTINF:-1 tvg-ID="PLEX.TV.073.The.Film.Detective" tvg-name="The Film Detective" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/the-film-detective.png" group-title="PLEX USA",The Film Detective
 https://filmdetective-plex.amagi.tv/amRdirect/us_privacy=1---&did=3f68a808-1437-5e57-9eaf-7a12279d9462&dnt=0&X-Plex-Token=nkPyxTGm41qFS7TFC9Yh&channelId=5eea605674085f0040ddc7a3/hls/amagi_hls_data_plexAAAAA-filmdetective-plex/CDN/1280x720_3256000/chunklist.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/OMqT9zb.jpg" group-title="PLEX USA",The Love Destination
+#EXTINF:-1 tvg-ID="PLEX.TV.058.Love.Destination" tvg-name="Love Destination" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/love-destination.png" group-title="PLEX USA",Love Destination
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=43&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5eea605674085f0040ddc7a9&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=0&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/3aHWa0R.jpg" group-title="PLEX USA",The Pet Collective
+#EXTINF:-1 tvg-ID="PLEX.TV.032.The.Pet.Collective" tvg-name="The Pet Collective" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/the_pet_collective_samsung_.png" group-title="PLEX USA",The Pet Collective
 https://631dd17512664bafa0f3d1bd9717d7c0.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex-intl_ThePetCollective/9a0bc894-3507-4712-ac73-40ae060ddbef/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/Tpn020B.jpg" group-title="PLEX USA",Toon Googles
+#EXTINF:-1 tvg-ID="" tvg-name="" tvg-logo="https://i.imgur.com/Tpn020B.jpg" group-title="PLEX USA",Toon Googles
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=36&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5f123330eca6a20040b328e8&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=1&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/AQneoQh.jpg" group-title="PLEX USA",Unidentivied
+#EXTINF:-1 tvg-ID="PLEX.TV.105.Unidentified" tvg-name="Unidentified" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/unidentified.png" group-title="PLEX USA",Unidentified
 https://studio1091-plex.amagi.tv/amRdirect/us_privacy=1---&did=3f68a808-1437-5e57-9eaf-7a12279d9462&dnt=0&X-Plex-Token=nkPyxTGm41qFS7TFC9Yh&channelId=5eea605374085f0040ddc764/hls/amagi_hls_data_plexAAAAA-unindentifiedtv-plex/CDN/1920x1080_5055600/index.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/YpkNhU4.jpg" group-title="PLEX USA",VENN
+#EXTINF:-1 tvg-ID="PLEX.TV.097.VENN" tvg-name="VENN" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/venn-logo.png" group-title="PLEX USA",VENN
 https://venntv-plex.amagi.tv/hls/amagi_hls_data_venntvAAA-venntv-plex/CDN/playlist.m3u8?us_privacy=1---&did=df8e1a36-847d-5096-86a7-3803ed330ede&dnt=0&X-Plex-Token=MorUy57ijWhGe4ixZb_T&channelId=5f74cf7dffbe690040689f3b%20
-#EXTINF:-1 tvg-logo="https://i.imgur.com/Ir8LX0x.jpg" group-title="PLEX USA",Weather Spy
+#EXTINF:-1 tvg-ID="PLEX.TV.103.WeatherSpy" tvg-name="WeatherSpy" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/jukin_weatherspy_1.png" group-title="PLEX USA",WeatherSpy
 https://04799df414944908856c6c521891945f.mediatailor.us-east-1.amazonaws.com/v1/manifest/44f73ba4d03e9607dcd9bebdcb8494d86964f1d8/Plex-intl_WeatherSpy/2eba863c-1452-4ea6-98b2-2b1c0c81c112/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/U0jjiIc.jpg" group-title="PLEX USA",Wu Tang
+#EXTINF:-1 tvg-ID="PLEX.TV.068.Wu.Tang.Collection" tvg-name="Wu Tang Collection" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/wu-tang-collection.png" group-title="PLEX USA",Wu Tang Collection
 https://stream-us-east-1.getpublica.com/playlist.m3u8?network_id=73&live=1&app_bundle=com.plexapp.desktop&did=df8e1a36-847d-5096-86a7-3803ed330ede&app_domain=app.plex.tv&app_name=plex&h=691&w=1224&content_title=MorUy57ijWhGe4ixZb_T&content_series=5eea605474085f0040ddc770&custom4=plex&gdpr=1&device_make=Windows&device_model=Firefox&coppa=0&us_privacy=1---
-#EXTINF:-1 tvg-logo="https://i.imgur.com/6CLldAA.jpg" group-title="PLEX USA",Yahoo! Finance
+#EXTINF:-1 tvg-ID="PLEX.TV.022.Yahoo!.Finance" tvg-name="Yahoo! Finance" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/yahoo-finance.png" group-title="PLEX USA",Yahoo! Finance
 https://yahoo-plex.amagi.tv/amRdirect/us_privacy=1---&did=61e24c69-c657-5bf3-b863-7cdc122e912c&dnt=0&X-Plex-Token=yd2t7_mqLeso7PyTUYZ6&channelId=5f170f01b898490041b49dd1/hls/amagi_hls_data_yahoofina-yahoofinance-plex/CDN/playlist.m3u8
-#EXTINF:-1 tvg-name="************ PLEX MUSIC USA *********",************ PLEX MUSIC USA *********
+#EXTINF:-1 tvg-ID="" tvg-name="************ PLEX MUSIC USA *********",************ PLEX MUSIC USA *********
 https://54d4596f49b947b987be6175b1a7a3f7.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/80s_party_plex/81854f83-4b79-442c-b943-8c87300fe190/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/MFbbITI.jpg" group-title="PLEX USA",80s Party
+#EXTINF:-1 tvg-ID="PLEX.TV.125.Loop.80's" tvg-name="Loop 80's" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-80s.png" group-title="PLEX USA",Loop 80's
 https://54d4596f49b947b987be6175b1a7a3f7.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/80s_party_plex/81854f83-4b79-442c-b943-8c87300fe190/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/pxtr7VO.jpg" group-title="PLEX USA",Beast Mode
+#EXTINF:-1 tvg-ID="PLEX.TV.128.Loop.Beast" tvg-name="Loop Beast" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-beast.png" group-title="PLEX USA",Loop Beast
 https://1f0e60dbce3043279c491fe51983361d.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/beast_mode_plex/dedcdc71-f8ba-4371-9ed9-e5fb2a691485/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/Lls2GLr.jpg" group-title="PLEX USA",Bedroom Beats
+#EXTINF:-1 tvg-ID="PLEX.TV.136.Loop.Bedroom" tvg-name="Loop Bedroom" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-bedroom.png" group-title="PLEX USA",Loop Bedroom
 https://eb8029576dd74625b1d49e34afc1febb.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/bedroom_beats_plex/932c2e9d-348a-4633-8a43-5e590398fde7/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/5MLGsFs.png" group-title="PLEX USA",Friday Feels
+#EXTINF:-1 tvg-ID="PLEX.TV.120.Loop.TGIF" tvg-name="Loop TGIF" tvg-logo="https://i.imgur.com/5MLGsFs.png" group-title="PLEX USA",Loop TGIF
 https://7d6f1eaab26244879085a9c647097af7.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/friday_feels_plex/8d5f1f7f-8546-4892-9eca-988e973d6cc2/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/EMcSZeW.jpg" group-title="PLEX USA",Hip Hop Bangers
+#EXTINF:-1 tvg-ID="PLEX.TV.129.Loop.Hip.Hop" tvg-name="Loop Hip Hop" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-hip-hop.png" group-title="PLEX USA",Loop Hip Hop
 https://e20b86263a38460ba3647b18fb150000.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/hip_hop_bangers_plex/ed8212a6-b4f2-46e7-8386-eab377eb0607/3.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/FzWHKTE.png" group-title="PLEX USA",Hottest of the Hot
+#EXTINF:-1 tvg-ID="PLEX.TV.121.Loop.Hottest" tvg-name="Loop Hottest" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-hottest.png" group-title="PLEX USA",Loop Hottest
 https://942aece530c1422894fddbd5867984d1.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/hottest_of_the_hot_plex/224447a1-0ef3-43cf-bb86-cb636669ba45/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/PsrGxob.png" group-title="PLEX USA",Like Yesterday
+#EXTINF:-1 tvg-ID="PLEX.TV.122.Loop.Flashback" tvg-name="Loop Flashback" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-flashback.png" group-title="PLEX USA",Loop Flashback
 https://7b65d9c562ad41b4b6efeaf1f598093d.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/like_yesterday_plex/11b32cf3-e807-4244-b949-6a22933cef3a/2.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/ymFMMn8.png" group-title="PLEX USA",Neural Focused
+#EXTINF:-1 tvg-ID="PLEX.TV.134.Loop.Synapse" tvg-name="Loop Synapse" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-synapse.png" group-title="PLEX USA",Loop Synapse
 https://1d75125ffd43490eb970a2f3f575e96c.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/neural_focused_plex/35cba159-09d0-4e37-bf3c-99cd99ec425b/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/gMj1BQR.jpg" group-title="PLEX USA",Only 90s Kids will understand
+#EXTINF:-1 tvg-ID="PLEX.TV.124.Loop.90's" tvg-name="Loop 90's" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-90s.png" group-title="PLEX USA",Loop 90's
 https://526cbf93692f48879c403ab8c1350e2a.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/90s_kids_plex/76979eef-8053-48eb-a1dc-b165e0d3dbf9/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/r9jJQXU.png" group-title="PLEX USA",Texas-Sized Hits
+#EXTINF:-1 tvg-ID="PLEX.TV.132.Loop.Texas.Tunes" tvg-name="Loop Texas Tunes" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-texas-tunes.png" group-title="PLEX USA",Loop Texas Tunes
 https://8d1615d8ec69435ea11a3e039f9e3771.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/texas_sized_hits_plex/b39ab3ff-fde8-42cf-a6e7-32e66a3da20a/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/aVkb7RV.jpg" group-title="PLEX USA",That 70s Channel
+#EXTINF:-1 tvg-ID="PLEX.TV.126.Loop.Far.Out" tvg-name="Loop Far Out" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-far-out.png" group-title="PLEX USA",Loop Far Out
 https://18a6ff4fa5424e6797030b139ca98e6c.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/that_70s_channel_plex/19b70c9a-59d0-418c-9cbc-80be9698c16b/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/xbLho4R.jpg" group-title="PLEX USA",That's Hot
+#EXTINF:-1 tvg-ID="PLEX.TV.123.Loop.That's.Hot" tvg-name="Loop That's Hot" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-thats-hot-v2.png" group-title="PLEX USA",Loop That's Hot
 https://fd80a2d7c3fb4580b4cb8ef661a96d49.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/thats_hot_plex/6fd86144-5938-4c3a-bda9-14ae30d6e38b/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/dpF2Hhh.png" group-title="PLEX USA",Trending
+#EXTINF:-1 tvg-ID="PLEX.TV.119.Loop.Trending" tvg-name="Loop Trending" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-trending-v2.png" group-title="PLEX USA",Loop Trending
 https://8f8959ec0c604ae0aac98fe0cda060eb.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/trending_plex/9ea57596-c36d-4991-802a-3f1961fb4e87/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/1QEigQ6.jpg" group-title="PLEX USA",Unwind
+#EXTINF:-1 tvg-ID="PLEX.TV.135.Loop.Unwind" tvg-name="Loop Unwind" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-unwind-v2.png" group-title="PLEX USA",Loop Unwind
 https://fc68583ae7094821b6ab3b44c50c7740.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/unwind_plex/3c8fb5fb-b196-45cc-9284-40da26a04a98/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/N6ouzgW.png" group-title="PLEX USA",Yacht Rock
+#EXTINF:-1 tvg-ID="PLEX.TV.137.Loop.Yacht.Rock" tvg-name="Loop Yacht Rock" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-yacht-rock-v2.png" group-title="PLEX USA",Loop Yacht Rock
 https://6f293d7819ba4cf39ea9152700ad54ad.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/yacht_rock_plex/eea1884a-76ca-461b-886d-9707c39c0fbb/5.m3u8
-#EXTINF:-1 tvg-logo="https://i.imgur.com/RAtVhO4.jpg" group-title="PLEX USA",Electro Anthems
+#EXTINF:-1 tvg-ID="PLEX.TV.133.Loop.Electronica" tvg-name="Loop Electronica" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/loop-electronica.png" group-title="PLEX USA",Loop Electronica
 https://57490d2f4ea646bbae56a1a816617a5f.mediatailor.us-west-2.amazonaws.com/v1/manifest/6b8beeb9ed833d048c8c8155a25a28fe617c5474/electro_anthems_plex/3f15c325-941b-4c87-b429-d93bd3e70738/5.m3u8


### PR DESCRIPTION
-Added tvg-IDs to match channel id's from plex2xml epg generator (https://github.com/ReenigneArcher/plex2xml)
-Updated logos to be high quality pngs with transparent backgrounds (all logos come from Plex's epg api)
-Updated channel names (all names come from Plex's epg api)

These streams are not plex streams:
-Camp Spoopy (above changes not applied)

These streams either do match Plex streams or are incorrectly labeled:
-MAV TV Select
-Party Tyme Karaoke
-TG Toon Googles (above changes not applied)
-Toon Googles (above changes not applied)