### PR TITLE
Update US06_USA_Plex.m3u

### DIFF
--- a/US06_USA_Plex.m3u
+++ b/US06_USA_Plex.m3u
@@ -261,3 +261,5 @@ https://epg.provider.plex.tv/library/parts/5e20b730f2f8d5003d739db7-5eea71d85252
 https://epg.provider.plex.tv/library/parts/5e20b730f2f8d5003d739db7-5eea71d85252710041e0ccf5?X-Plex-Token=MorUy57ijWhGe4ixZb_T
 #EXTINF:-1 tvg-ID="PLEX.TV.Party.Tyme.Karaoke" tvg-name="Party Tyme Karaoke" tvg-logo="https://provider-static.plex.tv/epg/images/ott_channels/logos/party-tyme-karaoke.png" group-title="PLEX USA",Party Tyme Karaoke
 https://epg.provider.plex.tv/library/parts/5e20b730f2f8d5003d739db7-5eea605674085f0040ddc7ac?X-Plex-Token=MorUy57ijWhGe4ixZb_T
+#EXTINF:-1 tvg-ID="" tvg-name="" tvg-logo="https://i.imgur.com/F6ca9IG.png" group-title="PLEX USA",PopcornFlix
+https://popcornflix-plex.amagi.tv/playlist.m3u8


### PR DESCRIPTION
Added PopcornFlix.
But note that this m3u is kind of a mess. This url format (epg.provider.plex.tv) has tokens that'll eventually expire as they're not the actual streams.
In addition to that, they're not in alphabetical order.