### PR TITLE
Update NZ Parliament logo

### DIFF
--- a/NZ01_NEWZEALAND.m3u
+++ b/NZ01_NEWZEALAND.m3u
@@ -7,7 +7,7 @@ https://uni01rtmp.tulix.tv/firstlight/firstlight.smil/playlist.m3u8
 https://ptvlive.kordia.net.nz/out/v1/3fc2254c865a457c8d7fbbce227a2aae/index.m3u8
 #EXTINF:-1 tvg-id="tv.13" tvg-name="Maori Television" tvg-logo="https://i.imgur.com/yo8kEk5.png" group-title="NEWZEALAND",Maori Television
 http://i.mjh.nz/nz/tv.13.m3u8
-#EXTINF:-1 tvg-name="Parliament TV" tvg-id="" group-title="NEWZEALAND" tvg-logo="https://i.imgur.com/Bmt34GV.png",Parliament TV
+#EXTINF:-1 tvg-name="Parliament TV" tvg-id="" group-title="NEWZEALAND" tvg-logo="https://www.parliament.nz/timeline/assets/logo.jpg",Parliament TV
 https://i.mjh.nz/nz/tv.18.m3u8
 #EXTINF:-1 tvg-id="tv.20" tvg-name="Te Reo - github.com/Free-IPTV" tvg-logo="https://i.imgur.com/UermurO.png" group-title="NEWZEALAND",Te Reo - github.com/Free-IPTV
 http://i.mjh.nz/nz/tv.20.m3u8


### PR DESCRIPTION
The logo shown for New Zealand's Parliament TV is from Australia. This updates the logo to the NZ House of Representatives.